### PR TITLE
fix gutil.pluginError issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function (options) {
                 results.push(lintErrors);
             }
         } catch (err) {
-            return cb(new gutil.pluginError(err.message.replace('null:', file.relative + ':')));
+            return cb(new gutil.PluginError('gulp-jscs-custom', err.message.replace('null:', file.relative + ':')));
         }
         return cb(null, file);
     }, function (cb) {


### PR DESCRIPTION
Hi,

Here is PR that fixes this issue I was having with `gulp-util` vers 3.0.4: 

```
/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/index.js:103
            return cb(new gutil.pluginError(err.message.replace('null:', file.
                      ^
TypeError: undefined is not a function
    at DestroyableTransform._transform (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/index.js:103:23)
    at DestroyableTransform.Transform._read (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp-jscs-custom/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/Users/wchegham/Sandbox/dev/XXXXX/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
    at DestroyableTransform.emit (events.js:92:17)
```

thx.
