### PR TITLE
Use consistent paths when loading custom reporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var gutil = require('gulp-util'),
     fs = require('fs'),
     Checker = require('jscs'),
     loadConfigFile = require('jscs/lib/cli-config'),
-    assign = require('object-assign');
+    assign = require('object-assign'),
+    path = require('path');
 
 /**
  * load a proper Reporter
@@ -15,7 +16,7 @@ var gutil = require('gulp-util'),
 function loadReporter(reporterPath) {
     var reporter;
     reporterPath = reporterPath || 'checkstyle';
-    if (!fs.existsSync(reporterPath)) {
+    if (!fs.existsSync(path.resolve(reporterPath))) {
         try {
             reporter = require('./lib/reporters/' + reporterPath);
         } catch (e) {
@@ -28,7 +29,7 @@ function loadReporter(reporterPath) {
         }
     } else {
         try {
-            reporter = require(reporterPath);
+            reporter = require(path.resolve(reporterPath));
         } catch (e) {
             reporter = null;
         }

--- a/index.js
+++ b/index.js
@@ -47,8 +47,12 @@ function writeOutput(filePath, content, cb) {
     var outStream;
     if (!filePath) {
         if (content) {
-            console.log(content);
+            console.log(content)
         }
+        
+        return cb(new gutil.PluginError('gulp-jscs-custom', 'JSCS validation failed', {
+            showStack: false
+        }))
         return cb();
     }
     outStream = fs.createWriteStream(filePath);
@@ -104,7 +108,6 @@ module.exports = function (options) {
         }
         return cb(null, file);
     }, function (cb) {
-        //console.log(results);
         if (results.length > 0) {
             writeOutput(options.filePath, reporter(results), cb);
         } else {


### PR DESCRIPTION
Solves an issue when trying to use a reporter from node_modules and specifying the path to that, for example node_modules/jscs-teamcity-reporter/teamcity-reporter.js
